### PR TITLE
Python 3.6> Syntax Fix

### DIFF
--- a/whois_similarity_distance/util/whois_obj.py
+++ b/whois_similarity_distance/util/whois_obj.py
@@ -188,7 +188,7 @@ class WhoisObj(object):
             elif not d:
                 print("PW, domain null " + str(self.domain) + " ")
         except WhoisException as e:
-            print("PW rejects " + str(self.domain) + ", ERROR TRACE " + e.message)
+            print("PW rejects " + str(self.domain) + ", ERROR TRACE " + str(e))
         except:
             print("PW rejects " + str(self.domain))
 


### PR DESCRIPTION
Exception object "e" must be printed with str(Object) syntax after Python 3.6.